### PR TITLE
Release v1.3.4

### DIFF
--- a/WSBC.ChatBots.Core/TokenInfo/TokenOptions.cs
+++ b/WSBC.ChatBots.Core/TokenInfo/TokenOptions.cs
@@ -5,6 +5,6 @@ namespace WSBC.ChatBots.Token
     public class TokenOptions
     {
         public string ContractAddress { get; set; } = "0x8244609023097aef71c702ccbaefc0bde5b48694";
-        public TimeSpan DataCacheLifetime { get; set; } = TimeSpan.FromSeconds(5);
+        public TimeSpan DataCacheLifetime { get; set; } = TimeSpan.FromSeconds(60);
     }
 }

--- a/WSBC.ChatBots.Core/WSBC.ChatBots.Core.csproj
+++ b/WSBC.ChatBots.Core/WSBC.ChatBots.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
     <Authors>TehGM and WallStreetBetsCoin Developers</Authors>
     <Company>WallStreetBetsCoin</Company>
     <Product>WSBC.ChatBots.Core</Product>

--- a/WSBC.ChatBots.Discord/WSBC.ChatBots.Discord.csproj
+++ b/WSBC.ChatBots.Discord/WSBC.ChatBots.Discord.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>WSBC.ChatBots.Discord</AssemblyName>
     <Authors>TehGM and WallStreetBetsCoin Developers</Authors>
     <Company>WallStreetBetsCoin</Company>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
     <Product>WSBC.ChatBots.Discord</Product>
     <PackageId>WSBC.ChatBots.Discord</PackageId>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/WSBC.ChatBots.Telegram/Commands/TokenCheckCommands.cs
+++ b/WSBC.ChatBots.Telegram/Commands/TokenCheckCommands.cs
@@ -39,8 +39,10 @@ namespace WSBC.ChatBots.Telegram.Commands
 
             this._handler.Register("/contract", "Gets WSBT token address", CmdAddress);
             this._handler.Register("/chart", "Gets links to price charts", CmdChart);
-            this._handler.Register("/price", "Gets current WSBT price (according to Dex-Trade)", CmdPrice);
-            this._handler.Register("/volume", "Gets WSBT trading volume (according to Dex-Trade)", CmdVolume);
+            //this._handler.Register("/price", "Gets current WSBT price (according to Dex-Trade)", CmdPrice);
+            this._handler.Register("/price", CmdPrice);
+            //this._handler.Register("/volume", "Gets WSBT trading volume (according to Dex-Trade)", CmdVolume);
+            this._handler.Register("/volume", CmdVolume);
         }
 
         private async void CmdAddress(ITelegramBotClient client, Message msg)
@@ -73,6 +75,13 @@ namespace WSBC.ChatBots.Telegram.Commands
             }
         }
 
+        private async void CmdPriceTemp(ITelegramBotClient client, Message msg)
+        {
+            string text = TelegramMardown.EscapeV2($"For exchange-independent price data, visit [poocoin](https://poocoin.app/tokens/0x8244609023097AeF71C702cCbaEFC0bde5b48694) or [dex.guru](https://dex.guru/token/0x8244609023097aef71c702ccbaefc0bde5b48694-bsc).");
+            await client.SendTextMessageAsync(msg.Chat.Id, text, ParseMode.MarkdownV2,
+                disableWebPagePreview: true, cancellationToken: this._cts.Token).ConfigureAwait(false);
+        }
+
         private async void CmdVolume(ITelegramBotClient client, Message msg)
         {
             try
@@ -95,6 +104,13 @@ namespace WSBC.ChatBots.Telegram.Commands
             {
                 await SendFailedRetrievingAsync(client, msg).ConfigureAwait(false);
             }
+        }
+
+        private async void CmdVolumeTemp(ITelegramBotClient client, Message msg)
+        {
+            string text = TelegramMardown.EscapeV2($"For exchange-independent volume data, visit [poocoin](https://poocoin.app/tokens/0x8244609023097AeF71C702cCbaEFC0bde5b48694) or [dex.guru](https://dex.guru/token/0x8244609023097aef71c702ccbaefc0bde5b48694-bsc).");
+            await client.SendTextMessageAsync(msg.Chat.Id, text, ParseMode.MarkdownV2,
+                disableWebPagePreview: true, cancellationToken: this._cts.Token).ConfigureAwait(false);
         }
 
         private async void CmdChart(ITelegramBotClient client, Message msg)

--- a/WSBC.ChatBots.Telegram/WSBC.ChatBots.Telegram.csproj
+++ b/WSBC.ChatBots.Telegram/WSBC.ChatBots.Telegram.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>WSBC.ChatBots.Telegram</AssemblyName>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
     <Authors>TehGM and WallStreetBetsCoin Developers</Authors>
     <Company>WallStreetBetsCoin</Company>
     <Description>Main Telegram Bot for WallStreetBets Coin and Token.</Description>


### PR DESCRIPTION
Temporarily disables Dex-Trade from being used for price and volume commands (Telegram)